### PR TITLE
[feat] 플레이리스트 API 연동

### DIFF
--- a/src/apis/playList.ts
+++ b/src/apis/playList.ts
@@ -1,0 +1,20 @@
+import { get } from './client';
+
+export const fetchMusics = async ({ pageParam = -1 }) => {
+  const response = await get('api/v1/1/musics', {
+    params: {
+      cursor: pageParam,
+    },
+  });
+
+  if (!response.data.data || response.data.data.length === 0) {
+    console.log('음악이 없음');
+  }
+
+  return {
+    items: response.data.data,
+    nextPage: response.data.data.length
+      ? response.data.data.slice(-1)[0].musicId
+      : undefined,
+  };
+};

--- a/src/components/playlistPage/MusicListComponent.tsx
+++ b/src/components/playlistPage/MusicListComponent.tsx
@@ -1,20 +1,43 @@
 import styled from 'styled-components';
-import { songs } from '../../constants/songs';
+import { useEffect, useState } from 'react';
 import PlayListItem from '../@common/PlayListItem';
+import useMusicInfiniteQuery from '../../hooks/queries/useMusicInfiniteQuery';
 
 const MusicListComponent = () => {
-  const handleClick = (title: string) => {
-    console.log(`Playing ${title}`);
-  };
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =
+    useMusicInfiniteQuery();
+  const [musics, setMusics] = useState([]);
+
+  useEffect(() => {
+    if (data?.pages) {
+      const newMusics = data.pages.flatMap((page) => page.items);
+      setMusics(newMusics);
+      console.log('musics', musics);
+    }
+  }, [data]);
+
+  useEffect(() => {
+    const onScroll = () => {
+      const scrollHeight = document.documentElement.scrollHeight;
+      const scrollTop = document.documentElement.scrollTop;
+      const clientHeight = document.documentElement.clientHeight;
+      if (scrollTop + clientHeight >= scrollHeight) {
+        console.log('로딩!');
+        fetchNextPage();
+      }
+    };
+
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [isFetchingNextPage, fetchNextPage]);
 
   return (
     <MusicListComponentWrapper>
-      {songs.map((song) => (
+      {musics.map((song) => (
         <PlayListItem
-          key={song.id}
-          title={song.title}
-          artist={song.artist}
-          onClick={() => handleClick(song.title)}
+          key={song.musicId}
+          title={song.musicTitle}
+          artist={song.singer}
         />
       ))}
     </MusicListComponentWrapper>
@@ -25,7 +48,7 @@ export default MusicListComponent;
 
 const MusicListComponentWrapper = styled.div`
   gap: 2.4rem;
-  margin: 1.2rem 2rem 0 2rem;
+  margin: 1.2rem 2rem 8.6rem 2rem;
   ${({ theme }) =>
     theme.mixin.flexCenter({
       direction: 'column',

--- a/src/hooks/queries/useMusicInfiniteQuery.tsx
+++ b/src/hooks/queries/useMusicInfiniteQuery.tsx
@@ -1,9 +1,11 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { fetchMusics } from '../../apis/playList';
 
+const QUERY_KEY_MUSICS = ['musics'];
+
 const useMusicInfiniteQuery = (cursor) => {
   return useInfiniteQuery({
-    queryKey: ['musics'],
+    queryKey: QUERY_KEY_MUSICS,
     queryFn: ({ pageParam = cursor }) => fetchMusics({ pageParam }),
     getNextPageParam: (lastPage, allPages) => lastPage.nextPage,
     initialPageParam: 0,

--- a/src/hooks/queries/useMusicInfiniteQuery.tsx
+++ b/src/hooks/queries/useMusicInfiniteQuery.tsx
@@ -1,0 +1,13 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { fetchMusics } from '../../apis/playList';
+
+const useMusicInfiniteQuery = (cursor) => {
+  return useInfiniteQuery({
+    queryKey: ['musics'],
+    queryFn: ({ pageParam = cursor }) => fetchMusics({ pageParam }),
+    getNextPageParam: (lastPage, allPages) => lastPage.nextPage,
+    initialPageParam: 0,
+  });
+};
+
+export default useMusicInfiniteQuery;

--- a/src/pages/playlistPage/PlaylistPage.tsx
+++ b/src/pages/playlistPage/PlaylistPage.tsx
@@ -17,6 +17,7 @@ const PlaylistPage = ({}: PlaylistPageProps) => {
       <LogoComponent />
       <MenuComponent />
       <MusicListComponent />
+      <BlankSection />
       <PlayComponent />
     </PlayListPageWrapper>
   );
@@ -46,4 +47,8 @@ const CardImgContainer = styled.div`
     width: 15rem;
     height: 15rem;
   }
+`;
+
+const BlankSection = styled.div`
+  height: 8.6rem;
 `;


### PR DESCRIPTION
<!-- PR 이름은 '[페이지명] 작업 내용'으로 통일할게요! -->
## 이슈 넘버
- close #43 
<!-- # 뒤에 이슈넘버를 써서 이슈를 닫아주세요 -->

## 구현 사항
<!-- 실제로 변경한 사항을 설명해주세요.-->

- [x] 플레이리스트 api 연동
- [x] 리엑트 쿼리의 `useInfiniteQuery`를 이용하여 무한 스크롤 기능 구현
- [x] 재생바에 하단 노래가 가려지는 현상 발생하여 플레이리스트 화면의 하단에 div태그 삽입

## Need Review
<!-- 어떤 부분에 리뷰어가 집중해야 하는지 or 해당 PR에서 논의가 필요한 사항을 적어주세요. -->

- 위로 스크롤 후 기다리면 '로딩!' 라는 로그가 찍히고 값이 불러와집니다. 
- 로딩 후 약간의 딜레이와 함께 음악이 불려옵니다. 너무 빠른 시간 내에 요청 시 무시됩니다.
- 더 이상 불러올 노래가 없을 시 '음악이 없음' 라는 로그가 찍힙니다.


## 📸 스크린샷
<!-- 팀원들이 이해하기 쉽도록 스크린샷을 첨부해주세요. -->



https://github.com/NOW-SOPT-CDSP-8/Spotify-FE/assets/128016888/7236387f-d703-4a9d-9239-e3ffac280056



## Reference
<!-- 참고한 사이트가 있다면 링크를 공유해주세요. -->
https://oliveyoung.tech/blog/2023-10-04/useInfiniteQuery-scroll/
https://tanstack.com/query/v4/docs/framework/react/reference/useInfiniteQuery